### PR TITLE
IAR support for USB host stack

### DIFF
--- a/os/hal/include/usbh.h
+++ b/os/hal/include/usbh.h
@@ -182,6 +182,7 @@ struct usbh_device {
 	usbh_devspeed_t speed;
 
 	USBH_DEFINE_BUFFER(usbh_device_descriptor_t, devDesc);
+	unsigned char align_bytes[2];
 	USBH_DEFINE_BUFFER(usbh_config_descriptor_t, basicConfigDesc);
 
 	uint8_t *fullConfigurationDescriptor;

--- a/os/hal/include/usbh/defs.h
+++ b/os/hal/include/usbh/defs.h
@@ -24,7 +24,7 @@
 
 #include "osal.h"
 
-typedef struct usbh_device_descriptor {
+typedef PACKED_VAR struct usbh_device_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint16_t bcdUSB;
@@ -39,11 +39,11 @@ typedef struct usbh_device_descriptor {
 	uint8_t  iProduct;
 	uint8_t  iSerialNumber;
 	uint8_t  bNumConfigurations;
-} __attribute__ ((packed)) usbh_device_descriptor_t;
+} usbh_device_descriptor_t;
 #define USBH_DT_DEVICE                   0x01
 #define USBH_DT_DEVICE_SIZE              18
 
-typedef struct usbh_config_descriptor {
+typedef PACKED_VAR struct usbh_config_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint16_t wTotalLength;
@@ -52,19 +52,19 @@ typedef struct usbh_config_descriptor {
 	uint8_t  iConfiguration;
 	uint8_t  bmAttributes;
 	uint8_t  bMaxPower;
-} __attribute__ ((packed)) usbh_config_descriptor_t;
+} usbh_config_descriptor_t;
 #define USBH_DT_CONFIG                   0x02
 #define USBH_DT_CONFIG_SIZE              9
 
-typedef struct usbh_string_descriptor {
+typedef PACKED_VAR struct usbh_string_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint16_t wData[1];
-} __attribute__ ((packed)) usbh_string_descriptor_t;
+} usbh_string_descriptor_t;
 #define USBH_DT_STRING                   0x03
 #define USBH_DT_STRING_SIZE              2
 
-typedef struct usbh_interface_descriptor {
+typedef PACKED_VAR struct usbh_interface_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint8_t  bInterfaceNumber;
@@ -74,22 +74,22 @@ typedef struct usbh_interface_descriptor {
 	uint8_t  bInterfaceSubClass;
 	uint8_t  bInterfaceProtocol;
 	uint8_t  iInterface;
-} __attribute__ ((packed)) usbh_interface_descriptor_t;
+} usbh_interface_descriptor_t;
 #define USBH_DT_INTERFACE                0x04
 #define USBH_DT_INTERFACE_SIZE           9
 
-typedef struct usbh_endpoint_descriptor {
+typedef PACKED_VAR struct usbh_endpoint_descriptor {
 	uint8_t	bLength;
 	uint8_t	bDescriptorType;
 	uint8_t	bEndpointAddress;
 	uint8_t	bmAttributes;
 	uint16_t wMaxPacketSize;
 	uint8_t	bInterval;
-} __attribute__ ((packed)) usbh_endpoint_descriptor_t;
+} usbh_endpoint_descriptor_t;
 #define USBH_DT_ENDPOINT                 0x05
 #define USBH_DT_ENDPOINT_SIZE            7
 
-typedef struct usbh_ia_descriptor {
+typedef PACKED_VAR struct usbh_ia_descriptor {
 	uint8_t  bLength;
 	uint8_t  bDescriptorType;
 	uint8_t  bFirstInterface;
@@ -98,11 +98,11 @@ typedef struct usbh_ia_descriptor {
 	uint8_t  bFunctionSubClass;
 	uint8_t  bFunctionProtocol;
 	uint8_t  iFunction;
-} __attribute__ ((packed)) usbh_ia_descriptor_t;
+} usbh_ia_descriptor_t;
 #define USBH_DT_INTERFACE_ASSOCIATION    	0x0b
 #define USBH_DT_INTERFACE_ASSOCIATION_SIZE	8
 
-typedef struct usbh_hub_descriptor {
+typedef PACKED_VAR struct usbh_hub_descriptor {
 	uint8_t  bDescLength;
 	uint8_t  bDescriptorType;
 	uint8_t  bNbrPorts;
@@ -110,17 +110,17 @@ typedef struct usbh_hub_descriptor {
 	uint8_t  bPwrOn2PwrGood;
 	uint8_t  bHubContrCurrent;
 	uint32_t DeviceRemovable;
-} __attribute__ ((packed)) usbh_hub_descriptor_t;
+} usbh_hub_descriptor_t;
 #define USBH_DT_HUB				    	0x29
 #define USBH_DT_HUB_SIZE		    	(7 + 4)
 
-typedef struct usbh_control_request {
+typedef PACKED_VAR struct usbh_control_request {
 	uint8_t  bmRequestType;
 	uint8_t  bRequest;
 	uint16_t wValue;
 	uint16_t wIndex;
 	uint16_t wLength;
-} __attribute__ ((packed)) usbh_control_request_t;
+} usbh_control_request_t;
 
 
 #define USBH_REQ_GET_STATUS              0x00

--- a/os/hal/include/usbh/list.h
+++ b/os/hal/include/usbh/list.h
@@ -7,6 +7,7 @@
 #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
 #endif
 
+#define container_of(ptr, type, member) ((type *)(void *)((char *)(ptr) - offsetof(type, member)))
 #ifndef container_of
 #define container_of(ptr, type, member) ({                  \
 	const typeof(((type *)0)->member) * __mptr = (ptr);     \
@@ -398,16 +399,16 @@ static inline void list_splice_tail_init(struct list_head *list,
  * @pos:        the type * to cursor
  * @member:     the name of the list_head within the struct.
  */
-#define list_next_entry(pos, member) \
-        list_entry((pos)->member.next, typeof(*(pos)), member)
+#define list_next_entry(pos, type, member) \
+        list_entry((pos)->member.next, type, member)
 
 /**
  * list_prev_entry - get the prev element in list
  * @pos:        the type * to cursor
  * @member:     the name of the list_head within the struct.
  */
-#define list_prev_entry(pos, member) \
-        list_entry((pos)->member.prev, typeof(*(pos)), member)
+#define list_prev_entry(pos, type, member) \
+        list_entry((pos)->member.prev, type, member)
 
 /**
  * list_for_each        -       iterate over a list
@@ -452,10 +453,10 @@ static inline void list_splice_tail_init(struct list_head *list,
  * @head:       the head for your list.
  * @member:     the name of the list_head within the struct.
  */
-#define list_for_each_entry(pos, head, member)                          \
-        for (pos = list_first_entry(head, typeof(*pos), member);        \
+#define list_for_each_entry(pos, type, head, member)                          \
+        for (pos = list_first_entry(head, type, member);        \
              &pos->member != (head);                                    \
-             pos = list_next_entry(pos, member))
+             pos = list_next_entry(pos, type, member))
 
 /**
  * list_for_each_entry_reverse - iterate backwards over list of given type.
@@ -463,10 +464,10 @@ static inline void list_splice_tail_init(struct list_head *list,
  * @head:       the head for your list.
  * @member:     the name of the list_head within the struct.
  */
-#define list_for_each_entry_reverse(pos, head, member)                  \
-        for (pos = list_last_entry(head, typeof(*pos), member);         \
+#define list_for_each_entry_reverse(pos, type, head, member)                  \
+        for (pos = list_last_entry(head, type, member);         \
              &pos->member != (head);                                    \
-             pos = list_prev_entry(pos, member))
+             pos = list_prev_entry(pos, type, member))
 
 /**
  * list_prepare_entry - prepare a pos entry for use in list_for_each_entry_continue()
@@ -476,8 +477,8 @@ static inline void list_splice_tail_init(struct list_head *list,
  *
  * Prepares a pos entry for use as a start point in list_for_each_entry_continue().
  */
-#define list_prepare_entry(pos, head, member) \
-        ((pos) ? : list_entry(head, typeof(*pos), member))
+#define list_prepare_entry(pos, type, head, member) \
+        ((pos) ? : list_entry(head, type, member))
 
 /**
  * list_for_each_entry_continue - continue iteration over list of given type
@@ -488,10 +489,10 @@ static inline void list_splice_tail_init(struct list_head *list,
  * Continue to iterate over list of given type, continuing after
  * the current position.
  */
-#define list_for_each_entry_continue(pos, head, member)                 \
-        for (pos = list_next_entry(pos, member);                        \
+#define list_for_each_entry_continue(pos, type, head, member)                 \
+        for (pos = list_next_entry(pos, type, member);                        \
              &pos->member != (head);                                    \
-             pos = list_next_entry(pos, member))
+             pos = list_next_entry(pos, type, member))
 
 /**
  * list_for_each_entry_continue_reverse - iterate backwards from the given point
@@ -502,10 +503,10 @@ static inline void list_splice_tail_init(struct list_head *list,
  * Start to iterate over list of given type backwards, continuing after
  * the current position.
  */
-#define list_for_each_entry_continue_reverse(pos, head, member)         \
-        for (pos = list_prev_entry(pos, member);                        \
+#define list_for_each_entry_continue_reverse(pos, type, head, member)         \
+        for (pos = list_prev_entry(pos, type, member);                        \
              &pos->member != (head);                                    \
-             pos = list_prev_entry(pos, member))
+             pos = list_prev_entry(pos, type, member))
 
 /**
  * list_for_each_entry_from - iterate over list of given type from the current point
@@ -515,9 +516,9 @@ static inline void list_splice_tail_init(struct list_head *list,
  *
  * Iterate over list of given type, continuing from current position.
  */
-#define list_for_each_entry_from(pos, head, member)                     \
+#define list_for_each_entry_from(pos, type, head, member)                     \
         for (; &pos->member != (head);                                  \
-             pos = list_next_entry(pos, member))
+             pos = list_next_entry(pos, type, member))
 
 /**
  * list_for_each_entry_safe - iterate over list of given type safe against removal of list entry
@@ -526,11 +527,11 @@ static inline void list_splice_tail_init(struct list_head *list,
  * @head:       the head for your list.
  * @member:     the name of the list_head within the struct.
  */
-#define list_for_each_entry_safe(pos, n, head, member)                  \
-        for (pos = list_first_entry(head, typeof(*pos), member),        \
-                n = list_next_entry(pos, member);                       \
+#define list_for_each_entry_safe(pos, type, n, head, member)                  \
+        for (pos = list_first_entry(head, type, member),        \
+                n = list_next_entry(pos, type, member);                       \
              &pos->member != (head);                                    \
-             pos = n, n = list_next_entry(n, member))
+             pos = n, n = list_next_entry(n, type, member))
 
 /**
  * list_for_each_entry_safe_continue - continue list iteration safe against removal
@@ -542,11 +543,11 @@ static inline void list_splice_tail_init(struct list_head *list,
  * Iterate over list of given type, continuing after current point,
  * safe against removal of list entry.
  */
-#define list_for_each_entry_safe_continue(pos, n, head, member)                 \
-        for (pos = list_next_entry(pos, member),                                \
-                n = list_next_entry(pos, member);                               \
+#define list_for_each_entry_safe_continue(pos, type, n, head, member)                 \
+        for (pos = list_next_entry(pos, type, member),                                \
+                n = list_next_entry(pos, type, member);                               \
              &pos->member != (head);                                            \
-             pos = n, n = list_next_entry(n, member))
+             pos = n, n = list_next_entry(n, type, member))
 
 /**
  * list_for_each_entry_safe_from - iterate over list from current point safe against removal
@@ -558,10 +559,10 @@ static inline void list_splice_tail_init(struct list_head *list,
  * Iterate over list of given type from current point, safe against
  * removal of list entry.
  */
-#define list_for_each_entry_safe_from(pos, n, head, member)                     \
-        for (n = list_next_entry(pos, member);                                  \
+#define list_for_each_entry_safe_from(pos, type, n, head, member)                     \
+        for (n = list_next_entry(pos, type, member);                                  \
              &pos->member != (head);                                            \
-             pos = n, n = list_next_entry(n, member))
+             pos = n, n = list_next_entry(n, type, member))
 
 /**
  * list_for_each_entry_safe_reverse - iterate backwards over list safe against removal
@@ -573,11 +574,11 @@ static inline void list_splice_tail_init(struct list_head *list,
  * Iterate backwards over list of given type, safe against removal
  * of list entry.
  */
-#define list_for_each_entry_safe_reverse(pos, n, head, member)          \
-        for (pos = list_last_entry(head, typeof(*pos), member),         \
-                n = list_prev_entry(pos, member);                       \
+#define list_for_each_entry_safe_reverse(pos, type, n, head, member)          \
+        for (pos = list_last_entry(head, type, member),         \
+                n = list_prev_entry(pos, type, member);                       \
              &pos->member != (head);                                    \
-             pos = n, n = list_prev_entry(n, member))
+             pos = n, n = list_prev_entry(n, type, member))
 
 /**
  * list_safe_reset_next - reset a stale list_for_each_entry_safe loop
@@ -591,7 +592,7 @@ static inline void list_splice_tail_init(struct list_head *list,
  * and list_safe_reset_next is called after re-taking the lock and before
  * completing the current iteration of the loop body.
  */
-#define list_safe_reset_next(pos, n, member)                            \
-        n = list_next_entry(pos, member)
+#define list_safe_reset_next(pos, type, n, member)                            \
+        n = list_next_entry(pos, type, member)
 
 #endif /* USBH_LIST_H_ */

--- a/os/hal/ports/STM32/LLD/USBHv1/usbh_lld.h
+++ b/os/hal/ports/STM32/LLD/USBHv1/usbh_lld.h
@@ -144,7 +144,11 @@ uint8_t usbh_lld_roothub_get_statuschange_bitmap(USBHDriver *usbh);
 
 #define usbh_lld_epreset(ep) do {(ep)->dt_mask = HCTSIZ_DPID_DATA0;} while (0);
 
+#ifdef __IAR_SYSTEMS_ICC__
+#define USBH_LLD_DEFINE_BUFFER(type, name) type name
+#else
 #define USBH_LLD_DEFINE_BUFFER(type, name) type name __attribute__((aligned(4)))
+#endif
 
 #endif
 

--- a/os/hal/src/usbh/usbh_hub.c
+++ b/os/hal/src/usbh/usbh_hub.c
@@ -16,6 +16,7 @@
 */
 
 #include "hal.h"
+#include "usbh/internal.h"
 
 #if HAL_USBH_USE_HUB
 
@@ -25,7 +26,6 @@
 
 #include <string.h>
 #include "usbh/dev/hub.h"
-#include "usbh/internal.h"
 
 #if USBHHUB_DEBUG_ENABLE_TRACE
 #define udbgf(f, ...)  usbDbgPrintf(f, ##__VA_ARGS__)


### PR DESCRIPTION
- changed list.h to eliminate using of typeof(), changed all calls in
  sources
- removed aligning in IAR due to automatic align(4) in IAR (except one
  place where aligning was added by two-bytes variable)
- changed GCC's atrribute packed to ChibiOS's PACKED_VAR
- now TEST UNIT READY placed before READ CAPACITY as dismirlian
  suggested
