### PR TITLE
Code cleanup to eliminate compiler warnings

### DIFF
--- a/os/hal/ports/STM32/LLD/USBHv1/usbh_lld.h
+++ b/os/hal/ports/STM32/LLD/USBHv1/usbh_lld.h
@@ -103,11 +103,9 @@ typedef struct stm32_hc_management {
 	uint16_t lld_c_status;		\
 	uint16_t lld_status;
 
-#define _usbh_device_ll_data 	\
-	;
+#define _usbh_device_ll_data
 
-#define _usbh_hub_ll_data		\
-	;
+#define _usbh_hub_ll_data
 
 #define _usbh_urb_ll_data		\
 	struct list_head node;		\

--- a/os/hal/src/usbh.c
+++ b/os/hal/src/usbh.c
@@ -155,7 +155,7 @@ void usbhEPObjectInit(usbh_ep_t *ep, usbh_device_t *dev, const usbh_endpoint_des
 	ep->device = dev;
 	ep->wMaxPacketSize = desc->wMaxPacketSize;
 	ep->address = desc->bEndpointAddress & 0x0F;
-	ep->type = desc->bmAttributes & 0x03;
+	ep->type = (usbh_eptype_t) (desc->bmAttributes & 0x03);
 	if (ep->type != USBH_EPTYPE_CTRL) {
 		ep->in = (desc->bEndpointAddress & 0x80) ? TRUE : FALSE;
 	}

--- a/os/hal/src/usbh/usbh_debug.c
+++ b/os/hal/src/usbh/usbh_debug.c
@@ -339,7 +339,7 @@ unsigned_common:
 		}
 	}
 
-	return n;
+	//return n; // can raise 'code is unreachable' warning
 
 }
 


### PR DESCRIPTION
- added typecasts
- non-reachable code commented
- moved declaration of two variables to eliminate 'control bypasses
  initialization' warnings
